### PR TITLE
Uses actual battlefield size, rather than 800x600.

### DIFF
--- a/src/BulletWave.java
+++ b/src/BulletWave.java
@@ -13,12 +13,12 @@ public class BulletWave {
 	private double power;
 	private double confidence;
 
-	public BulletWave(Vector position, double power, int startAngle, int endAngle, double confidence) {
+	public BulletWave(Vector position, double power, int startAngle, int endAngle, double confidence, State state) {
 		this.power = power;
 		this.confidence = confidence;
 		this.bullets = new ArrayList<VirtualBullet>();
 		for(int i = startAngle; i < endAngle; i++) {
-			this.bullets.add(new VirtualBullet(position, this.power, Utils.normalAbsoluteAngleDegrees(i)));
+			this.bullets.add(new VirtualBullet(position, this.power, Utils.normalAbsoluteAngleDegrees(i), state));
 		}
 		this.advance();
 	}

--- a/src/OtherRobot.java
+++ b/src/OtherRobot.java
@@ -193,7 +193,7 @@ public class OtherRobot implements Comparable<OtherRobot> {
         // assume the robot was aiming at us
         int angle = (int) Util.getAngle(previous.position.getX(), previous.position.getY(),
                                         state.owner.getX(), state.owner.getY());
-        this.bulletWaves.add(new BulletWave(previous.position, power, angle - 10, angle + 10, confidence));
+        this.bulletWaves.add(new BulletWave(previous.position, power, angle - 10, angle + 10, confidence, state));
 
         return true;
     }

--- a/src/ProjectedBot.java
+++ b/src/ProjectedBot.java
@@ -140,7 +140,7 @@ public class ProjectedBot
             }
             if (locX > state.battleWidth - 16/*width of arena*/)
             {
-                locX = 800 - 16;
+                locX = state.battleWidth - 16;
                 speed = 0;
             }
             if (locY < 16)
@@ -150,7 +150,7 @@ public class ProjectedBot
             }
             if (locY > state.battleHeight - 16 /*height of arena*/)
             {
-                locY = 600 - 16;
+                locY = state.battleHeight - 16;
                 speed = 0;
             }
         }

--- a/src/VirtualBullet.java
+++ b/src/VirtualBullet.java
@@ -7,19 +7,21 @@ public class VirtualBullet {
     private Vector position;
     private Vector velocity;
     private long flightTime;
+    private State state;
 
-    public VirtualBullet(Vector position, double power, double angleD) {
+    public VirtualBullet(Vector position, double power, double angleD, State state) {
         double angleR = Math.toRadians(angleD);
         double speed = Util.firepowerToSpeed(power);
         this.position = new Vector(position);
         this.velocity = new Vector(Math.sin(angleR) * speed, Math.cos(angleR) * speed);
         this.flightTime = 0;
+        this.state = state;
     }
 
     public boolean advance() {
         this.flightTime++;
         this.position = this.position.add(this.velocity);
-        if (Util.isOutOfBattleField(this.position.getX(), this.position.getY(), 800, 600)) {
+        if (Util.isOutOfBattleField(this.position.getX(), this.position.getY(), state.battleWidth, state.battleHeight)) {
             return false;
         }
         return true;


### PR DESCRIPTION
Changes to ProjectedBot and VirtualBullet to use state.battleWidth and
state.battleHeight where appropriate (instead of 800 and 600).
Changes to BulletWave, VirtualBullet and OtherRobot to pass state through to
VirtualBullet.advance().
